### PR TITLE
Make it easier to build without GLFW installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ endif (HAVE_LIB_M)
 
 find_package(PkgConfig)
 pkg_check_modules(OSMESA REQUIRED osmesa)
-pkg_check_modules(GLFW3 REQUIRED glfw3)
 pkg_check_modules(ZLIB REQUIRED zlib)
 pkg_check_modules(VULKAN REQUIRED vulkan)
 
@@ -91,6 +90,8 @@ if (EXTERNAL_GLFW)
     link_directories(${GLFW_LIBRARY_DIR})
     set(GLFW_LIBS_ALL ${GLFW_LIBRARIES} ${EXTRA_LIBS})
 else ()
+    pkg_check_modules(GLFW3 REQUIRED glfw3)
+
     add_definitions(${GLFW3_CFLAGS})
     set(GLFW_LIBS_ALL ${GLFW3_LDFLAGS} ${EXTRA_LIBS})
 endif ()

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The project has been tested on Ubuntu 20.04.1 LTS (Focal Fossa).
 Use the following command to install dependencies on _Ubuntu 20.04_:
 
 ```
-sudo apt-get install -y cmake ninja-build libosmesa6-dev libopengl-dev libvulkan-dev
+sudo apt-get install -y cmake ninja-build libosmesa6-dev libopengl-dev libvulkan-dev xorg-dev
 ```
 
 #### Building the demo


### PR DESCRIPTION
Since `pkg_check_modules(GLFW3 REQUIRED glfw3)` is always invoked, GLFW must be installed even if using the external project. I move that to only be invoked if `EXTERNAL_GLFW` is off.

GLFW depends on the `xorg-dev` packages, so I also added that to the list of dependencies in the README.

Together these are sufficient to build on a fresh machine:

```
# apt install ... xorg-dev
$ cmake -B build
$ cmake --build build
$ build/kitty_gears
```